### PR TITLE
changed some Syntax issues to make it run with >=PHP7.4

### DIFF
--- a/barcode_api/examples/barcode_api_use/barcode/barcode.class.php
+++ b/barcode_api/examples/barcode_api_use/barcode/barcode.class.php
@@ -1876,7 +1876,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=0; $i<strlen($barnumber); $i++) {
-			$num	= (int)$barnumber{$i};
+			$num	= (int)$barnumber[$i];
 			$even	= (substr($encTable[$checkdigit], $i, 1) == 'E');
 			if(!$even)
 				$mfcStr .= $leftOdd[$num];
@@ -2055,9 +2055,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++) {
 			if($i % 2 == 0)
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 			else
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 		}
 		
 		// Calculate the checksum digit
@@ -2101,7 +2101,7 @@ class BARCODE {
 		
 		// Encoding data
 		for ($i=0; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 4)  {
 				$mfcStr .= $leftOdd[$num];
 			} else if ($i >= 4) {
@@ -2277,9 +2277,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++)  {
 			if($i % 2 == 0 )
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 			else
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 		}
 		
 		// Calculate the checksum digit
@@ -2324,7 +2324,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=1; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 7)  {
 				$even = (substr($encTable[$encbit], $i - 1, 1) == 1);
 				if(!$even)

--- a/barcode_api/examples/barcode_api_use/barcode/datamatrix.php
+++ b/barcode_api/examples/barcode_api_use/barcode/datamatrix.php
@@ -627,7 +627,7 @@ class Datamatrix {
 					if ($numch[ENC_C40] == $numch[ENC_X12]) {
 						$k = ($pos + $charscount + 1);
 						while ($k < $data_length) {
-							$tmpchr = ord($data{$k});
+							$tmpchr = ord($data[$k]);
 							if ($this->isCharMode($tmpchr, ENC_X12)) {
 								return ENC_X12;
 							} elseif (!($this->isCharMode($tmpchr, ENC_X12) OR $this->isCharMode($tmpchr, ENC_C40))) {

--- a/barcode_api/examples/barcode_api_use/barcode/pdf417.php
+++ b/barcode_api/examples/barcode_api_use/barcode/pdf417.php
@@ -878,7 +878,7 @@ class PDF417 {
 				$txtarr = array(); // array of characters and sub-mode switching characters
 				$codelen = strlen($code);
 				for ($i = 0; $i < $codelen; ++$i) {
-					$chval = ord($code{$i});
+					$chval = ord($code[$i]);
 					if (($k = array_search($chval, $this->textsubmodes[$submode])) !== false) {
 						// we are on the same sub-mode
 						$txtarr[] = $k;
@@ -947,7 +947,7 @@ class PDF417 {
 						} while ($t != '0');
 					} else {
 						for ($i = 0; $i < $sublen; ++$i) {
-							$cw[] = ord($code{$i});
+							$cw[] = ord($code[$i]);
 						}
 					}
 					$code = $rest;

--- a/barcode_api/examples/barcode_gen_ui/barcode/barcode.class.php
+++ b/barcode_api/examples/barcode_gen_ui/barcode/barcode.class.php
@@ -1876,7 +1876,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=0; $i<strlen($barnumber); $i++) {
-			$num	= (int)$barnumber{$i};
+			$num	= (int)$barnumber[$i];
 			$even	= (substr($encTable[$checkdigit], $i, 1) == 'E');
 			if(!$even)
 				$mfcStr .= $leftOdd[$num];
@@ -2055,9 +2055,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++) {
 			if($i % 2 == 0)
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 			else
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 		}
 		
 		// Calculate the checksum digit
@@ -2101,7 +2101,7 @@ class BARCODE {
 		
 		// Encoding data
 		for ($i=0; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 4)  {
 				$mfcStr .= $leftOdd[$num];
 			} else if ($i >= 4) {
@@ -2277,9 +2277,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++)  {
 			if($i % 2 == 0 )
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 			else
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 		}
 		
 		// Calculate the checksum digit
@@ -2324,7 +2324,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=1; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 7)  {
 				$even = (substr($encTable[$encbit], $i - 1, 1) == 1);
 				if(!$even)

--- a/barcode_api/examples/barcode_gen_ui/barcode/datamatrix.php
+++ b/barcode_api/examples/barcode_gen_ui/barcode/datamatrix.php
@@ -627,7 +627,7 @@ class Datamatrix {
 					if ($numch[ENC_C40] == $numch[ENC_X12]) {
 						$k = ($pos + $charscount + 1);
 						while ($k < $data_length) {
-							$tmpchr = ord($data{$k});
+							$tmpchr = ord($data[$k]);
 							if ($this->isCharMode($tmpchr, ENC_X12)) {
 								return ENC_X12;
 							} elseif (!($this->isCharMode($tmpchr, ENC_X12) OR $this->isCharMode($tmpchr, ENC_C40))) {

--- a/barcode_api/examples/barcode_gen_ui/barcode/pdf417.php
+++ b/barcode_api/examples/barcode_gen_ui/barcode/pdf417.php
@@ -878,7 +878,7 @@ class PDF417 {
 				$txtarr = array(); // array of characters and sub-mode switching characters
 				$codelen = strlen($code);
 				for ($i = 0; $i < $codelen; ++$i) {
-					$chval = ord($code{$i});
+					$chval = ord($code[$i]);
 					if (($k = array_search($chval, $this->textsubmodes[$submode])) !== false) {
 						// we are on the same sub-mode
 						$txtarr[] = $k;
@@ -947,7 +947,7 @@ class PDF417 {
 						} while ($t != '0');
 					} else {
 						for ($i = 0; $i < $sublen; ++$i) {
-							$cw[] = ord($code{$i});
+							$cw[] = ord($code[$i]);
 						}
 					}
 					$code = $rest;

--- a/barcode_api/examples/barcode_simpler_examples/barcode/barcode.class.php
+++ b/barcode_api/examples/barcode_simpler_examples/barcode/barcode.class.php
@@ -1876,7 +1876,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=0; $i<strlen($barnumber); $i++) {
-			$num	= (int)$barnumber{$i};
+			$num	= (int)$barnumber[$i];
 			$even	= (substr($encTable[$checkdigit], $i, 1) == 'E');
 			if(!$even)
 				$mfcStr .= $leftOdd[$num];
@@ -2055,9 +2055,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++) {
 			if($i % 2 == 0)
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 			else
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 		}
 		
 		// Calculate the checksum digit
@@ -2101,7 +2101,7 @@ class BARCODE {
 		
 		// Encoding data
 		for ($i=0; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 4)  {
 				$mfcStr .= $leftOdd[$num];
 			} else if ($i >= 4) {
@@ -2277,9 +2277,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++)  {
 			if($i % 2 == 0 )
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 			else
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 		}
 		
 		// Calculate the checksum digit
@@ -2324,7 +2324,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=1; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 7)  {
 				$even = (substr($encTable[$encbit], $i - 1, 1) == 1);
 				if(!$even)

--- a/barcode_api/examples/barcode_simpler_examples/barcode/datamatrix.php
+++ b/barcode_api/examples/barcode_simpler_examples/barcode/datamatrix.php
@@ -627,7 +627,7 @@ class Datamatrix {
 					if ($numch[ENC_C40] == $numch[ENC_X12]) {
 						$k = ($pos + $charscount + 1);
 						while ($k < $data_length) {
-							$tmpchr = ord($data{$k});
+							$tmpchr = ord($data[$k]);
 							if ($this->isCharMode($tmpchr, ENC_X12)) {
 								return ENC_X12;
 							} elseif (!($this->isCharMode($tmpchr, ENC_X12) OR $this->isCharMode($tmpchr, ENC_C40))) {

--- a/barcode_api/examples/barcode_simpler_examples/barcode/pdf417.php
+++ b/barcode_api/examples/barcode_simpler_examples/barcode/pdf417.php
@@ -878,7 +878,7 @@ class PDF417 {
 				$txtarr = array(); // array of characters and sub-mode switching characters
 				$codelen = strlen($code);
 				for ($i = 0; $i < $codelen; ++$i) {
-					$chval = ord($code{$i});
+					$chval = ord($code[$i]);
 					if (($k = array_search($chval, $this->textsubmodes[$submode])) !== false) {
 						// we are on the same sub-mode
 						$txtarr[] = $k;
@@ -947,7 +947,7 @@ class PDF417 {
 						} while ($t != '0');
 					} else {
 						for ($i = 0; $i < $sublen; ++$i) {
-							$cw[] = ord($code{$i});
+							$cw[] = ord($code[$i]);
 						}
 					}
 					$code = $rest;

--- a/barcode_api/mainfiles/barcode.class.php
+++ b/barcode_api/mainfiles/barcode.class.php
@@ -1834,7 +1834,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=0; $i<strlen($barnumber); $i++) {
-			$num	= (int)$barnumber{$i};
+			$num	= (int)$barnumber[$i];
 			$even	= (substr($encTable[$checkdigit], $i, 1) == 'E');
 			if(!$even)
 				$mfcStr .= $leftOdd[$num];
@@ -2004,9 +2004,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++) {
 			if($i % 2 == 0)
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 			else
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 		}
 		
 		// Calculate the checksum digit
@@ -2050,7 +2050,7 @@ class BARCODE {
 		
 		// Encoding data
 		for ($i=0; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 4)  {
 				$mfcStr .= $leftOdd[$num];
 			} else if ($i >= 4) {
@@ -2217,9 +2217,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++)  {
 			if($i % 2 == 0 )
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 			else
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 		}
 		
 		// Calculate the checksum digit
@@ -2264,7 +2264,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=1; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 7)  {
 				$even = (substr($encTable[$encbit], $i - 1, 1) == 1);
 				if(!$even)

--- a/barcode_api/mainfiles/datamatrix.php
+++ b/barcode_api/mainfiles/datamatrix.php
@@ -627,7 +627,7 @@ class Datamatrix {
 					if ($numch[ENC_C40] == $numch[ENC_X12]) {
 						$k = ($pos + $charscount + 1);
 						while ($k < $data_length) {
-							$tmpchr = ord($data{$k});
+							$tmpchr = ord($data[$k]);
 							if ($this->isCharMode($tmpchr, ENC_X12)) {
 								return ENC_X12;
 							} elseif (!($this->isCharMode($tmpchr, ENC_X12) OR $this->isCharMode($tmpchr, ENC_C40))) {

--- a/barcode_api/mainfiles/pdf417.php
+++ b/barcode_api/mainfiles/pdf417.php
@@ -878,7 +878,7 @@ class PDF417 {
 				$txtarr = array(); // array of characters and sub-mode switching characters
 				$codelen = strlen($code);
 				for ($i = 0; $i < $codelen; ++$i) {
-					$chval = ord($code{$i});
+					$chval = ord($code[$i]);
 					if (($k = array_search($chval, $this->textsubmodes[$submode])) !== false) {
 						// we are on the same sub-mode
 						$txtarr[] = $k;
@@ -947,7 +947,7 @@ class PDF417 {
 						} while ($t != '0');
 					} else {
 						for ($i = 0; $i < $sublen; ++$i) {
-							$cw[] = ord($code{$i});
+							$cw[] = ord($code[$i]);
 						}
 					}
 					$code = $rest;

--- a/mainfiles/barcode.class.php
+++ b/mainfiles/barcode.class.php
@@ -1834,7 +1834,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=0; $i<strlen($barnumber); $i++) {
-			$num	= (int)$barnumber{$i};
+			$num	= (int)$barnumber[$i];
 			$even	= (substr($encTable[$checkdigit], $i, 1) == 'E');
 			if(!$even)
 				$mfcStr .= $leftOdd[$num];
@@ -2004,9 +2004,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++) {
 			if($i % 2 == 0)
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 			else
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 		}
 		
 		// Calculate the checksum digit
@@ -2050,7 +2050,7 @@ class BARCODE {
 		
 		// Encoding data
 		for ($i=0; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 4)  {
 				$mfcStr .= $leftOdd[$num];
 			} else if ($i >= 4) {
@@ -2217,9 +2217,9 @@ class BARCODE {
 		// Calculate the checksum value for the message
 		for($i=0; $i<strlen($barnumber); $i++)  {
 			if($i % 2 == 0 )
-				$csumTotal = $csumTotal + intval($barnumber{$i});
+				$csumTotal = $csumTotal + intval($barnumber[$i]);
 			else
-				$csumTotal = $csumTotal + (3 * intval($barnumber{$i}));
+				$csumTotal = $csumTotal + (3 * intval($barnumber[$i]));
 		}
 		
 		// Calculate the checksum digit
@@ -2264,7 +2264,7 @@ class BARCODE {
 		
 		// Encoding data
 		for($i=1; $i<strlen($barnumber); $i++) {
-			$num = (int)$barnumber{$i};
+			$num = (int)$barnumber[$i];
 			if($i < 7)  {
 				$even = (substr($encTable[$encbit], $i - 1, 1) == 1);
 				if(!$even)

--- a/mainfiles/pdf417.php
+++ b/mainfiles/pdf417.php
@@ -878,7 +878,7 @@ class PDF417 {
 				$txtarr = array(); // array of characters and sub-mode switching characters
 				$codelen = strlen($code);
 				for ($i = 0; $i < $codelen; ++$i) {
-					$chval = ord($code{$i});
+					$chval = ord($code[$i]);
 					if (($k = array_search($chval, $this->textsubmodes[$submode])) !== false) {
 						// we are on the same sub-mode
 						$txtarr[] = $k;
@@ -947,7 +947,7 @@ class PDF417 {
 						} while ($t != '0');
 					} else {
 						for ($i = 0; $i < $sublen; ++$i) {
-							$cw[] = ord($code{$i});
+							$cw[] = ord($code[$i]);
 						}
 					}
 					$code = $rest;


### PR DESCRIPTION
Changed the curly brackets to square brackets:

for example:
$array{$i} to $array[$i]

Since PHP7.4 the old syntax is deprecated, it won´t run on PHP8.1 anymore.